### PR TITLE
Add .gitattributes with linguist settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sql linguist-detectable=true
+*.sql linguist-language=PLpgSQL

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+* linguist-vendored
 *.sql linguist-detectable=true
 *.sql linguist-language=PLpgSQL


### PR DESCRIPTION
Make GitHub think that all `*.sql` files are written in PLpgSQL instead of (partly) TSQL.

>Note: Once merged, the language statistics will not update immediately, only once GitHubs background worker comes around to do so.